### PR TITLE
fix: remove selected random instance from candidates

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"slices"
 	"strings"
 	"time"
 
@@ -225,7 +226,7 @@ func sendRequestRandomInstance(instances []InfluxDBInstance, url string, queryVa
 	instance := instances[choice]
 
 	// remove selected instance to prevent reselected againg.
-	instances = append(instances[:choice], instances[choice+1:]...)
+	instances = slices.Concat(instances[:choice], instances[choice+1:])
 
 	log.Printf("Sending request to %s\n", instance.URL)
 	resp, err := sendRequestWithRetry(instance.URL+url, queryValues, request, false)


### PR DESCRIPTION
This PR simplifies `sendRequestRandomInstance` and fixes re-selecting random instance twice.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the issue of re-selecting the same random instance by removing it from the candidates list after selection, and simplify the `sendRequestRandomInstance` function by eliminating redundant parameters and logic.

Bug Fixes:
- Fix re-selecting the same random instance twice by removing the selected instance from the candidates list.

Enhancements:
- Simplify the `sendRequestRandomInstance` function by removing unnecessary parameters and logic.

<!-- Generated by sourcery-ai[bot]: end summary -->